### PR TITLE
NixOS 25.05 upgrade and development tooling improvements

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -2,7 +2,9 @@
   "permissions": {
     "allow": [
       "Bash(nix flake metadata:*)",
-      "Bash(grep:*)"
+      "Bash(grep:*)",
+      "Bash(nix-store:*)",
+      "Bash(nix why-depends:*)"
     ]
   },
   "enableAllProjectMcpServers": false

--- a/flake.lock
+++ b/flake.lock
@@ -1,8 +1,67 @@
 {
   "nodes": {
+    "codex": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "rust-overlay": "rust-overlay"
+      },
+      "locked": {
+        "lastModified": 1755734224,
+        "narHash": "sha256-oT6wK/35Cl9iVFf0TlIuryc11nTUIOQYd//knwXUM/w=",
+        "owner": "openai",
+        "repo": "codex",
+        "rev": "b3f958c24e4c4350c06220bbafd9982de13e3acb",
+        "type": "github"
+      },
+      "original": {
+        "owner": "openai",
+        "repo": "codex",
+        "rev": "b3f958c24e4c4350c06220bbafd9982de13e3acb",
+        "type": "github"
+      }
+    },
     "flake-utils": {
       "inputs": {
         "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_2": {
+      "inputs": {
+        "systems": "systems_2"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_3": {
+      "inputs": {
+        "systems": "systems_3"
       },
       "locked": {
         "lastModified": 1731533236,
@@ -25,33 +84,33 @@
         ]
       },
       "locked": {
-        "lastModified": 1747688870,
-        "narHash": "sha256-ypL9WAZfmJr5V70jEVzqGjjQzF0uCkz+AFQF7n9NmNc=",
+        "lastModified": 1755928099,
+        "narHash": "sha256-OILVkfhRCm8u18IZ2DKR8gz8CVZM2ZcJmQBXmjFLIfk=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "d5f1f641b289553927b3801580598d200a501863",
+        "rev": "4a44fb9f7555da362af9d499817084f4288a957f",
         "type": "github"
       },
       "original": {
         "owner": "nix-community",
-        "ref": "release-24.11",
+        "ref": "release-25.05",
         "repo": "home-manager",
         "type": "github"
       }
     },
     "nix-vscode-extensions": {
       "inputs": {
-        "flake-utils": "flake-utils",
+        "flake-utils": "flake-utils_2",
         "nixpkgs": [
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1750730765,
-        "narHash": "sha256-MIcOcvxqAXUv2TJjf19aVXdtVrD8Gkcfi4W4pKkT0Lw=",
+        "lastModified": 1756173634,
+        "narHash": "sha256-CCdn2ynIm9B1K8ymTHwoGVycDO9hJLk93yBV7yaaBwc=",
         "owner": "nix-community",
         "repo": "nix-vscode-extensions",
-        "rev": "1a1442e13dc1730de0443f80dcf02658365e999a",
+        "rev": "289217638eab2937a76f60b1497f2998942c61d7",
         "type": "github"
       },
       "original": {
@@ -62,11 +121,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1750431636,
-        "narHash": "sha256-vnzzBDbCGvInmfn2ijC4HsIY/3W1CWbwS/YQoFgdgPg=",
+        "lastModified": 1755330281,
+        "narHash": "sha256-aJHFJWP9AuI8jUGzI77LYcSlkA9wJnOIg4ZqftwNGXA=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "1552a9f4513f3f0ceedcf90320e48d3d47165712",
+        "rev": "3dac8a872557e0ca8c083cdcfc2f218d18e113b0",
         "type": "github"
       },
       "original": {
@@ -78,43 +137,27 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1750646418,
-        "narHash": "sha256-4UAN+W0Lp4xnUiHYXUXAPX18t+bn6c4Btry2RqM9JHY=",
+        "lastModified": 1755922037,
+        "narHash": "sha256-wY1+2JPH0ZZC4BQefoZw/k+3+DowFyfOxv17CN/idKs=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "1f426f65ac4e6bf808923eb6f8b8c2bfba3d18c5",
+        "rev": "b1b3291469652d5a2edb0becc4ef0246fff97a7c",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
-        "ref": "nixos-24.11",
+        "ref": "nixos-25.05",
         "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs-ollama": {
-      "locked": {
-        "lastModified": 1712849433,
-        "narHash": "sha256-flQtf/ZPJgkLY/So3Fd+dGilw2DKIsiwgMEn7BbBHL0=",
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "f173d0881eff3b21ebb29a2ef8bedbc106c86ea5",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "f173d0881eff3b21ebb29a2ef8bedbc106c86ea5",
         "type": "github"
       }
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1750506804,
-        "narHash": "sha256-VLFNc4egNjovYVxDGyBYTrvVCgDYgENp5bVi9fPTDYc=",
+        "lastModified": 1756125398,
+        "narHash": "sha256-XexyKZpf46cMiO5Vbj+dWSAXOnr285GHsMch8FBoHbc=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "4206c4cb56751df534751b058295ea61357bbbaa",
+        "rev": "3b9f00d7a7bf68acd4c4abb9d43695afb04e03a5",
         "type": "github"
       },
       "original": {
@@ -134,11 +177,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1748196248,
-        "narHash": "sha256-1iHjsH6/5UOerJEoZKE+Gx1BgAoge/YcnUsOA4wQ/BU=",
+        "lastModified": 1754501628,
+        "narHash": "sha256-FExJ54tVB5iu7Dh2tLcyCSWpaV+lmUzzWKZUkemwXvo=",
         "owner": "pjones",
         "repo": "plasma-manager",
-        "rev": "b7697abe89967839b273a863a3805345ea54ab56",
+        "rev": "cca090f8115c4172b9aef6c5299ae784bdd5e133",
         "type": "github"
       },
       "original": {
@@ -149,13 +192,35 @@
     },
     "root": {
       "inputs": {
+        "codex": "codex",
         "home-manager": "home-manager",
         "nix-vscode-extensions": "nix-vscode-extensions",
         "nixos-hardware": "nixos-hardware",
         "nixpkgs": "nixpkgs",
-        "nixpkgs-ollama": "nixpkgs-ollama",
         "nixpkgs-unstable": "nixpkgs-unstable",
-        "plasma-manager": "plasma-manager"
+        "plasma-manager": "plasma-manager",
+        "wifitui": "wifitui"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "nixpkgs": [
+          "codex",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1755657401,
+        "narHash": "sha256-rPHuWPAcwW63wH1SUtDCqAnf2+60pi/pGMCIhVobzXc=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "292ca754b0f679b842fbfc4734f017c351f0e9eb",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
       }
     },
     "systems": {
@@ -170,6 +235,57 @@
       "original": {
         "owner": "nix-systems",
         "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_2": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_3": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "wifitui": {
+      "inputs": {
+        "flake-utils": "flake-utils_3",
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1756153499,
+        "narHash": "sha256-MTBJTHGz8UE0OwzJXiI412V79xW4gfxeTRzx+5vkG8U=",
+        "owner": "shazow",
+        "repo": "wifitui",
+        "rev": "c223ec4cc7341c02e97bd8f823cfd04ca257c489",
+        "type": "github"
+      },
+      "original": {
+        "owner": "shazow",
+        "repo": "wifitui",
         "type": "github"
       }
     }

--- a/flake.nix
+++ b/flake.nix
@@ -2,12 +2,12 @@
   description = "John's NixOS configuration";
 
   inputs = {
-    nixpkgs.url = "github:nixos/nixpkgs/nixos-24.11";
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-25.05";
     nixpkgs-unstable.url = "github:nixos/nixpkgs/nixos-unstable";
     nixos-hardware.url = "github:NixOS/nixos-hardware/master";
     
     home-manager = {
-      url = "github:nix-community/home-manager/release-24.11";
+      url = "github:nix-community/home-manager/release-25.05";
       inputs.nixpkgs.follows = "nixpkgs";
     };
     
@@ -22,28 +22,29 @@
       inputs.home-manager.follows = "home-manager";
     };
 
-    # Special version needed for ollama
-    nixpkgs-ollama.url = "github:nixos/nixpkgs/f173d0881eff3b21ebb29a2ef8bedbc106c86ea5";
+    codex = {
+      url = "github:openai/codex/b3f958c24e4c4350c06220bbafd9982de13e3acb";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+
+    wifitui = {
+      url = "github:shazow/wifitui";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
   };
 
-  outputs = { self, nixpkgs, nixpkgs-unstable, nixos-hardware, home-manager, nix-vscode-extensions, plasma-manager, nixpkgs-ollama, ... }@inputs:
+  outputs = { self, nixpkgs, nixpkgs-unstable, home-manager, ... }@inputs:
     let
       system = "x86_64-linux";
       
       # Configure pkgs instances
-      pkgs = import nixpkgs {
-        inherit system;
-        config.allowUnfree = true;
-        config.rocmSupport = true;
-      };
-
       pkgs-unstable = import nixpkgs-unstable {
         inherit system;
         config.allowUnfree = true;
         config.rocmSupport = true;
       };
 
-      pkgs-ollama = import nixpkgs-ollama {
+      pkgs = import nixpkgs {
         inherit system;
         config.allowUnfree = true;
         config.rocmSupport = true;
@@ -66,7 +67,7 @@
       mkHost = hostPath: extraModules: lib.nixosSystem {
         inherit system;
         specialArgs = inputs // {
-          inherit pkgs-unstable pkgs-ollama;
+          inherit pkgs-unstable;
         };
         modules = [
           hostPath

--- a/home/john/home.nix
+++ b/home/john/home.nix
@@ -1,4 +1,4 @@
-{ config, pkgs, pkgs-unstable, nix-vscode-extensions, plasma-manager, ... }:
+{ config, pkgs, pkgs-unstable, nix-vscode-extensions, codex, wifitui, ... }:
 
 let
   system = pkgs.stdenv.hostPlatform.system;
@@ -36,7 +36,7 @@ in
     enableCompletion = true;
     syntaxHighlighting.enable = true;
     historySubstringSearch.enable = true;
-    initExtra = ''
+    initContent = ''
       ZSH_AUTOSUGGEST_STRATEGY=(history)
 
       . /home/john/repos/dotfiles/zshrc
@@ -80,11 +80,14 @@ in
       bradlc.vscode-tailwindcss
     ];
   };
+  home.sessionVariables = {
+    OLLAMA_HOST = "127.0.0.1:11434";
+  };
   home.packages = [
     pkgs.just
     pkgs.kitty
     pkgs.kitty-themes
-    (pkgs.nerdfonts.override { fonts = [ "FiraCode" ]; })
+    pkgs.nerd-fonts.fira-code
     pkgs.jq
     pkgs.fzf
     pkgs.kdePackages.skanpage
@@ -93,6 +96,7 @@ in
     pkgs.vlc
     pkgs.lmodern
     pkgs.tree
+    pkgs.ripgrep
   ] ++ [
     pkgs-unstable.python3Full
     pkgs-unstable.nodejs_22
@@ -110,5 +114,8 @@ in
     pkgs-unstable.galaxy-buds-client
     pkgs-unstable.google-chrome
     pkgs-unstable.claude-code
+    pkgs-unstable.gemini-cli
+    codex.packages.${system}.codex-rs
+    wifitui.packages.${system}.default
   ];
 }

--- a/home/john/home.nix
+++ b/home/john/home.nix
@@ -13,9 +13,8 @@ in
   home.homeDirectory = "/home/john";
   home.stateVersion = "23.11";
 
-  # home-manager should manage itself and allow unfree packages.
+  # home-manager should manage itself.
   programs.home-manager.enable = true;
-  nixpkgs.config.allowUnfree = true;
   programs.direnv.enable = true;
 
   # fonts
@@ -73,7 +72,7 @@ in
   programs.vscode = {
     enable = true;
     package = pkgs-unstable.vscode;
-    extensions = with vscode-extensions.vscode-marketplace; [
+    profiles.default.extensions = with vscode-extensions.vscode-marketplace; [
       pkgs.vscode-extensions.github.copilot
     ] ++ [
       ms-vscode.vscode-typescript-next

--- a/hosts/venator/configuration.nix
+++ b/hosts/venator/configuration.nix
@@ -123,7 +123,7 @@
       compositor = "kwin";
     };
   };
-  services.xserver.desktopManager.plasma5.enable = true;
+  services.desktopManager.plasma6.enable = true;
   services.hardware.bolt.enable = true;
 
   # Configure keymap in X11
@@ -166,7 +166,7 @@
   ];
 
   # Enable sound with pipewire.
-  hardware.pulseaudio.enable = false;
+  services.pulseaudio.enable = false;
   services.pipewire = {
     enable = true;
     alsa.enable = true;

--- a/hosts/venator/configuration.nix
+++ b/hosts/venator/configuration.nix
@@ -2,7 +2,7 @@
 # your system.  Help is available in the configuration.nix(5) man page
 # and in the NixOS manual (accessible by running 'nixos-help').
 
-{ config, pkgs, pkgs-unstable, pkgs-ollama, lib, nixos-hardware, ... }:
+{ config, pkgs, pkgs-unstable, lib, nixos-hardware, nixpkgs, nixpkgs-unstable, ... }:
 
 {
   imports =
@@ -82,11 +82,15 @@
       defaultNetwork.settings.dns_enabled = true;
     };
   };
-  # Uncomment to enable ollama containers
-  # containers = (import ../../modules/ollama.nix {
-  #   nixpkgs = pkgs-ollama.outPath;
-  #   lib = pkgs-ollama.lib;
-  # }).containers;
+
+  containers = (import ../../modules/ollama.nix {
+    inherit nixpkgs lib;
+    devices = [
+      "/dev/kfd"
+      "/dev/dri/card1"      # Discrete GPU (RX 6650 XT/6700S/6800S)
+      "/dev/dri/renderD128" # Discrete GPU render node
+    ];
+  }).containers;
 
   # Set your time zone.
   # time.timeZone = "America/Chicago";
@@ -198,8 +202,13 @@
     };
   };
 
-  # Enable touchpad support (enabled default in most desktopManager).
-  # services.xserver.libinput.enable = true;
+  services.keybase.enable = true;
+  services.kbfs = {
+    enable = true;
+    enableRedirector = true;
+  };
+  security.wrappers.keybase-redirector.owner = "john";
+  security.wrappers.keybase-redirector.group = "users";
 
   # Extra groups
   users.groups.plugdev = {};
@@ -252,6 +261,7 @@
     libgcc
     # UI utils
     kdePackages.plasma-thunderbolt
+    keybase-gui
   ] ++ [
     pkgs-unstable.zsa-udev-rules
     pkgs-unstable.devenv

--- a/modules/ollama.nix
+++ b/modules/ollama.nix
@@ -26,10 +26,13 @@
     };
     config = { pkgs, lib, ... }: {
       networking.firewall.allowedTCPPorts = [ port ];
+      networking.nameservers = [ "1.1.1.1" "8.8.8.8" ];
       services.ollama = {
+        package = pkgs.ollama-rocm;
         enable = true;
         acceleration = "rocm";
-        listenAddress = "${containerHostAddr}:${toString port}";
+        host = containerHostAddr;
+        port = port;
         environmentVariables = {
           HSA_OVERRIDE_GFX_VERSION = "10.3.0";
         };


### PR DESCRIPTION
## Summary
- Upgrade NixOS from 24.11 to 25.05 with Home Manager compatibility
- Fix Ollama container DNS configuration for internet access
- Add new development CLI tools and services

## Changes

### Infrastructure Updates
- **NixOS 25.05 Upgrade**: Updated nixpkgs and home-manager to 25.05 release
- **Ollama Container Fix**: Added DNS servers (1.1.1.1, 8.8.8.8) to resolve internet connectivity issues
- **GPU Configuration**: Enabled discrete GPU support for Ollama with proper device mapping

### New Development Tools
- **OpenAI Codex CLI**: Added Rust-based Codex tool for AI-assisted coding
- **WiFiTUI**: Terminal-based WiFi network management interface
- **Gemini CLI**: Google Gemini API command-line client
- **ripgrep**: Fast text search tool

### Services & Configuration
- **Keybase Integration**: Enabled Keybase service with KBFS and GUI support
- **Container Infrastructure**: Activated Ollama container with ROCm acceleration
- **Environment Variables**: Set OLLAMA_HOST for seamless container access

## Test plan
- [x] System builds successfully with `nixos-rebuild switch`
- [x] Ollama container can download models (DNS resolution working)
- [x] GPU acceleration confirmed in Ollama logs (ROCm detected)
- [x] Home Manager packages install correctly
- [x] New CLI tools accessible in PATH