### PR TITLE
fix(darwin): disable Spotlight indexing on /nix volume

### DIFF
--- a/modules/darwin/base.nix
+++ b/modules/darwin/base.nix
@@ -39,6 +39,14 @@
   security.pam.services.sudo_local.touchIdAuth = true;
   security.pam.services.sudo_local.reattach = true;
 
+  # Disable Spotlight indexing on /nix to prevent old package versions
+  # from appearing in Launchpad and desktop search results
+  system.activationScripts.postActivation.text = ''
+    if mdutil -s /nix 2>/dev/null | grep -q "Indexing enabled"; then
+      mdutil -i off -d /nix
+    fi
+  '';
+
   # macOS-specific system packages
   environment.systemPackages = with pkgs; [
     # macOS utilities


### PR DESCRIPTION
## Summary
- Spotlight indexes old package versions in `/nix/store`, causing duplicate apps (kitty, VS Code, Zed, etc.) to appear in Launchpad and on the desktop after updates
- Adds a post-activation script that disables Spotlight indexing on the `/nix` APFS volume and erases the existing index
- Idempotent: only runs `mdutil` if indexing is currently enabled

## Test plan
- [ ] Run `sudo darwin-rebuild switch --flake .#macbook`
- [ ] Verify `mdutil -s /nix` shows indexing disabled
- [ ] Confirm duplicate app versions no longer appear in Launchpad/desktop